### PR TITLE
Handle allocation, permission and channel refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Implements:
 ```elixir
 def deps do
   [
-    {:ex_turn, "~> 0.1.1"}
+    {:ex_turn, "~> 0.2.0"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ExTURN.MixProject do
   use Mix.Project
 
-  @version "0.1.1"
+  @version "0.2.0"
   @source_url "https://github.com/elixir-webrtc/ex_turn"
 
   def project do


### PR DESCRIPTION
This PR:
* handles stale nonce error responses by re-executing previous request with a new nonce
* fixes allocation, permissions refresh and adds missing channels refresh
* invalidates allocation, permissions or channels if it doesn't get refresh success response